### PR TITLE
Hide initiative via class for module compatibility

### DIFF
--- a/sta-initiative.css
+++ b/sta-initiative.css
@@ -4,3 +4,6 @@ body.system-sta #combat-round > nav:nth-child(2) > a.combat-control
 {
 	display: none;
 }
+.hideInitiativeMessage {
+	display: none !important;
+}

--- a/sta-initiative.js
+++ b/sta-initiative.js
@@ -73,7 +73,7 @@ Hooks.on('renderChatMessage', (cm, jq) =>
 {
 	if (STAInitiative.shouldHideChatMessage(cm))
 	{
-		jq[0].style.display = 'none';
+		jq.addClass("hideInitiativeMessage");
 	}
  	else if (STAInitiative.shouldCensorChatMessage(cm))
 	{


### PR DESCRIPTION
I noticed, that another module, namely https://github.com/jdeon/foundryVTT-pinned-chatlog-module, changes the visibility of the hidden initiative messages back.
So i changed the way the messages are hidden to a CSS class, which ignores the style-attribute set by other modules.